### PR TITLE
Add subchart values to parent chart values

### DIFF
--- a/infrastructure/charts/values.yaml
+++ b/infrastructure/charts/values.yaml
@@ -27,3 +27,100 @@ postgresql:
       postgresql.ambassador/init-revision: "1"
   metrics:
     enabled: false
+
+## values for indexer subchart
+indexer:
+  replicaCount: 1
+  
+  appConfig:
+    ambassador: # ambassador-specific configuration as defined in application.yml
+      security:
+        enabled: false
+      source:
+        name: gitlab
+        url: https://fake
+        token: fake
+        system: fake
+  
+  image:
+    repository: ghcr.io/roche/ambassador-indexer
+    pullPolicy: IfNotPresent
+    # Overrides the image tag whose default is the chart appVersion.
+    tag: "latest"
+  
+  nameOverride: ""
+  fullnameOverride: ""
+  
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # Annotations to add to the service account
+    annotations: {}
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ""
+  
+  podAnnotations: {}
+  
+  podSecurityContext:
+    runAsNonRoot: true
+    fsGroup: 2000
+  
+  securityContext:
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    runAsUser: 1000
+    privileged: false
+    runAsNonRoot: true
+  
+  service:
+    type: ClusterIP
+    port: 8080
+  
+  ingress:
+    enabled: true
+    className: ""
+    annotations: {}
+      # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+    hosts:
+      - host: kubernetes.docker.internal
+        paths:
+          - path: /
+            pathType: Prefix
+    tls: []
+    #  - secretName: chart-example-tls
+    #    hosts:
+    #      - chart-example.local
+  
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+  #   memory: 128Mi
+  
+  pdb:
+    minAvailable: 1
+  #  maxUnavailable:
+  
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 1 # not supported yet
+    targetCPUUtilizationPercentage: 80
+    # targetMemoryUtilizationPercentage: 80
+  
+  nodeSelector: {}
+  
+  tolerations: []
+  
+  affinity: {}


### PR DESCRIPTION
Add indexer subchart values to parent values.yaml.

Based on: https://helm.sh/docs/chart_template_guide/subcharts_and_globals/#overriding-values-from-a-parent-chart